### PR TITLE
Changed "Username" to "Password" in the web UI.

### DIFF
--- a/bin/routerosint.py
+++ b/bin/routerosint.py
@@ -52,7 +52,7 @@ SCHEME = """<scheme>
 
             <arg name="ROUTEROS_PASSWORD">
                 <title>Password</title>
-                <description>Username for your RouterOS Device</description>
+                <description>Password for your RouterOS Device</description>
             </arg>
         </args>
     </endpoint>

--- a/bin/routerosinv.py
+++ b/bin/routerosinv.py
@@ -52,7 +52,7 @@ SCHEME = """<scheme>
 
             <arg name="ROUTEROS_PASSWORD">
                 <title>Password</title>
-                <description>Username for your RouterOS Device</description>
+                <description>Password for your RouterOS Device</description>
             </arg>
         </args>
     </endpoint>

--- a/bin/routerosperf.py
+++ b/bin/routerosperf.py
@@ -52,7 +52,7 @@ SCHEME = """<scheme>
 
             <arg name="ROUTEROS_PASSWORD">
                 <title>Password</title>
-                <description>Username for your RouterOS Device</description>
+                <description>Password for your RouterOS Device</description>
             </arg>
         </args>
     </endpoint>


### PR DESCRIPTION
A New "Data input" for webform for "Mikrotik Routeros Interface Stats", "Mikrotik Routeros Inventory" and "Mikrotik Routeros Performance" has got "Username" instead of "Password".

